### PR TITLE
Fix for relative URLs not working sometimes.

### DIFF
--- a/page-links-to.php
+++ b/page-links-to.php
@@ -430,6 +430,11 @@ class CWS_PageLinksTo extends WP_Stack_Plugin {
 			if ( $this->get_target( $post->ID ) )
 				$this->log_target( $post->ID );
 		}
+		
+		if ( $link[0] == "/" ) {
+                  //It's a relative url
+                  return (is_ssl() ? 'https://' : 'http://') . $_SERVER["HTTP_HOST"] . $link;
+                }
 
 		return $link;
 	}


### PR DESCRIPTION
This Wordpress hook (and therefore this function) is required to return an absolute URL.
Therefore to make relative URLs work the URL must be checked and converted to be absolute before being returned.

This bug has gone unnoticed for a long time as in most cases returning a relative URL will still work. However in some cases it will not work and an update to Wordpress may stop it working with relative URLs at all (as it is not meant to work with them).

I noticed that if I set up a page to link to another using this plugin (and a relative URL) and then type a URL very similar to the url of the page I just created it exposes this bug and redirects me to completely the wrong URL.

What happens is that Wordpress notices the invalid URL and then searches for the correct URL using url mangling rules. Wordpress then tries to send you the correct page but this plugin then correctly tries to redirect you to the page your are linking to. Instead of getting this page you get the relative url being appended to the current page url with a ":" therefore meaning that you get a 404 error instead and the Page Links To plugin does not work correctly.

Kind regards,
Shanee Vanstone.
