### PR TITLE
Register metadata to facilitate editing the custom field values via XMLRPC API

### DIFF
--- a/page-links-to.php
+++ b/page-links-to.php
@@ -84,6 +84,10 @@ class CWS_PageLinksTo extends WP_Stack_Plugin {
 		$this->hook( 'save_post'           );
 		$this->hook( 'wp_nav_menu_objects' );
 		$this->hook( 'plugin_row_meta'     );
+
+		// Metadata validation grants users editing privileges for our custom fields
+		register_meta('post', self::LINK_META_KEY, null, '__return_true');
+		register_meta('post', self::TARGET_META_KEY, null, '__return_true');
 	}
 
 	/**


### PR DESCRIPTION
Without this regsitration, the user would have to either be a network super admin or else have their own custom plugin to facilitate using an app such as MarsEdit to edit the custom fields values for these values.