### PR TITLE
Fix PHP Notice

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -748,6 +748,10 @@ class CWS_PageLinksTo {
 	 * @return string the modified HTML block.
 	 */
 	function wp_list_pages( $output, $_args = array(), $pages = array() ) {
+		if ( empty( $pages ) ) {
+			return $output;
+		}
+
 		$highlight = false;
 
 		$this_url = esc_url_raw( set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );


### PR DESCRIPTION
Often the `$pages` variable is set to false on some first single post loads.

```
Notice: Trying to get property of non-object in /application/www/wp-content/plugins/page-links-to/classes/plugin.php on line 749
```

Notice screenshot: http://p.tri.be/MrEoLu