### PR TITLE
Add the ability to completely disable open-in-new-tab feature with a filter

### DIFF
--- a/src/block-editor.js
+++ b/src/block-editor.js
@@ -10,15 +10,6 @@ import { Fragment, Component } from '@wordpress/element';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 
-// function PanelGroup({ children }) {
-// 	const style = {
-// 		display: 'flex',
-// 		flexDirection: 'column',
-// 	};
-
-// 	return <div style={style}>{children}</div>;
-// }
-
 class LinksTo extends Component {
 	constructor(props) {
 		super(props);
@@ -130,14 +121,16 @@ class LinksTo extends Component {
 								placeholder="https://"
 							/>
 						</PanelRow>
-						<PanelRow>
-							<CheckboxControl
-								label="Open in new tab"
-								data-testid="plt-newtab"
-								checked={this.opensInNewTab()}
-								onChange={onUpdateNewTab}
-							/>
-						</PanelRow>
+						{window.pltOptions.supports.newTab && (
+							<PanelRow>
+								<CheckboxControl
+									label="Open in new tab"
+									data-testid="plt-newtab"
+									checked={this.opensInNewTab()}
+									onChange={onUpdateNewTab}
+								/>
+							</PanelRow>
+						)}
 					</>
 				)}
 			</PluginDocumentSettingPanel>


### PR DESCRIPTION
You can now do this:

add_filter( 'page_links_to_supports_new_tab', '__return_false' );

This disables:

1. All of the new tab UI (classic and block editor).
2. The output of the JS that opens new tab links in new tabs.
3. The code that "marks" links as new tab link with a special anchor.

fixes #72