### PR TITLE
Stop constant updating of postmeta

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -306,6 +306,8 @@ class CWS_PageLinksTo {
 			if ( $total_affected > 0 ) {
 				wp_cache_flush();
 			}
+			// Set the version key, in the instance where the plugin wasn't previously used.
+			update_option( self::VERSION_KEY, 3, false );
 		}
 	}
 


### PR DESCRIPTION
When the plugin wasn't used previously, the postmeta keys are constantly updated, due to no option being saved, this should fix this.